### PR TITLE
allow dots in 'name' parameter

### DIFF
--- a/iptables_raw.py
+++ b/iptables_raw.py
@@ -279,10 +279,10 @@ class Iptables:
     # Key used for unmanaged rules
     UNMANAGED_RULES_KEY_NAME = '$unmanaged_rules$'
 
-    # Only allow alphanumeric characters, underscore, hyphen, or a space for
+    # Only allow alphanumeric characters, underscore, hyphen, dots, or a space for
     # now. We don't want to have problems while parsing comments using regular
     # expressions.
-    RULE_NAME_ALLOWED_CHARS = 'a-zA-Z0-9_ -'
+    RULE_NAME_ALLOWED_CHARS = 'a-zA-Z0-9_ -\.'
 
     module = None
 


### PR DESCRIPTION
- allow the usage of {{ inventory_hostname }} as input for the 'name' parameter when the inventory hostname is a fully qualified domain name